### PR TITLE
Updating Provider::getUserByToken() to use the given token

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -39,7 +39,7 @@ class Provider extends AbstractProvider implements ProviderInterface
         $response = $this->getHttpClient()->get(
             'https://api.stripe.com/v1/account', [
             'headers' => [
-                'Authorization' => 'Bearer '.$this->clientSecret,
+                'Authorization' => 'Bearer '.$token,
             ],
         ]);
 


### PR DESCRIPTION
Without this you just end up authenticating your own account over and over again.
